### PR TITLE
macOS / Apple Silicon support and two portability bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,66 @@ Usage
    docker run -d -p 23:23 gjchen/qkmj
 ```
 
+Building and running locally (macOS / Apple Silicon)
+====================================================
+
+The server and client build natively on macOS (Apple Silicon, arm64) — no
+Docker or emulation required. You need the Xcode command-line tools
+(`xcode-select --install`); the client links the system `ncurses`.
+
+```
+# 1. Build the server (mjgps) and the admin record tool (mjrec)
+cd qkmjserver && make && cd ..
+
+# 2. Build the terminal client (qkmj)
+cd qkmjclient && make && cd ..
+```
+
+Run it (each in its own terminal tab):
+
+```
+qkmjserver/mjgps 7001            # the game server, listening on port 7001
+qkmjclient/qkmj 127.0.0.1 7001   # the client; run one per player
+```
+
+A full game needs four clients connected to one table (there are no bots):
+open four tabs, log in under four different names, have one type `/serv` to
+open a table and the other three `/join <that-name>`. Type `/help` in-game
+for the command list.
+
+Data directory
+--------------
+
+The server stores accounts and logs in a data directory, resolved at startup:
+
+* `$QKMJ_DATA_DIR` if that environment variable is set, otherwise
+* `$HOME/.qkmj`
+
+It is created automatically on first run — no `sudo` and no manual setup. The
+admin tool reads the same file, e.g. `qkmjserver/mjrec ~/.qkmj/qkmj.rec`.
+
+Terminal encoding
+-----------------
+
+The UI (including the table borders) is **Big5**-encoded. Set your terminal's
+character encoding to Traditional Chinese (Big5) or the Chinese text and
+box-drawing will show as garbage. iTerm2 (Profiles → Terminal → Character
+Encoding → Big5) works well; `luit -encoding Big5 qkmjclient/qkmj ...` is an
+alternative that keeps a UTF-8 terminal.
+
+macOS / Apple Silicon changes in this fork
+------------------------------------------
+
+This fork adds macOS support on top of TonyQ's QKMJ (originally by 吳先祐 /
+Shian-Yow Wu, remastered/dockerized by gjchen). Changes:
+
+* Fixed `init_socket()` in the client to return success explicitly — it
+  previously fell off the end and returned an undefined value, which on arm64
+  is typically negative and made the client wrongly report "cannot connect".
+* Moved the server data files out of a hardcoded `/var/qkrecord` (which needed
+  `sudo`) to `$QKMJ_DATA_DIR` / `$HOME/.qkmj`, auto-created at startup.
+* Build fixes for modern clang/gcc (`<termios.h>`, `<stdlib.h>`, forward
+  declarations, `-std=gnu89`), and cross-platform Makefiles.
+
+The Docker/WebSocket path above is unchanged.
+

--- a/qkmjclient/makefile
+++ b/qkmjclient/makefile
@@ -3,7 +3,10 @@
 CC=gcc
 
 # OPTS= -finput-charset=UTF-8
-OPTS=-DNON_WINDOWS=1
+# -std=gnu89 + the -Wno-* flags let this K&R-era code build under modern
+# clang (macOS) and recent gcc, which otherwise treat implicit-int /
+# implicit-declaration / mismatched signal() handlers as hard errors.
+OPTS=-DNON_WINDOWS=1 -std=gnu89 -Wno-implicit-int -Wno-implicit-function-declaration -Wno-int-conversion -Wno-return-type -Wno-incompatible-function-pointer-types
 
 
 qkmj: qkmj.o input.o screen.o socket.o command.o message.o check.o checkscr.o card.o chkmake.o misc.o 

--- a/qkmjclient/qkmj.h
+++ b/qkmjclient/qkmj.h
@@ -131,5 +131,6 @@ extern char table_card[6][17];
 
 /* ------------------------------------------------------------------ */
 extern int leave();
+void show_card(char card, int x, int y, int type);  /* fwd decl: used before its definition in screen.c */
 
 

--- a/qkmjclient/socket.c
+++ b/qkmjclient/socket.c
@@ -106,6 +106,7 @@ init_socket(char *host,int portnum,int *sockfd)
   {
     return -1;
   }
+  return 0;
 }
 
 accept_new_client()

--- a/qkmjserver/Makefile
+++ b/qkmjserver/Makefile
@@ -3,15 +3,32 @@ OBJECT = test_gf.o rscoder.o rs.o
 TARGET = mjgps mjrec
 TARGETWIN = mjgpswin mjrecwin
 
-CC = gcc 
+CC = gcc
+
+UNAME_S := $(shell uname -s)
+
+# K&R-era C: relax diagnostics that modern clang / recent gcc treat as errors
+# (implicit int, implicit function declarations, etc.).
+WARN = -Wno-implicit-int -Wno-implicit-function-declaration \
+       -Wno-int-conversion -Wno-return-type
+
+CFLAGS = -O2 -fomit-frame-pointer -pipe -std=gnu89 $(WARN)
+
+# Platform differences:
+#   crypt() lives in libc on macOS but needs -lcrypt on Linux/BSD.
+#   Static linking (-static) is unsupported on macOS.
+ifeq ($(UNAME_S),Darwin)
+  CRYPTLIB =
+  RECSTATIC =
+else
+  CRYPTLIB = -lcrypt
+  RECSTATIC = -static
+endif
 
 #Cygwin version
-CWFLAGS = -O2  -mtune=generic -v -fomit-frame-pointer -pipe -lcrypt /bin/cygcrypt-0.dll 
+CWFLAGS = -O2  -mtune=generic -v -fomit-frame-pointer -pipe -lcrypt /bin/cygcrypt-0.dll
 
-#Linux Version
-CFLAGS = -O2  -mtune=generic -v -fomit-frame-pointer -pipe -lcrypt 
-  
-LDFLAGS = $(CFLAGS) -s
+LDFLAGS = $(CFLAGS)
 
 .c.o:
 	$(CC) -c $(CFLAGS) $<
@@ -19,11 +36,11 @@ LDFLAGS = $(CFLAGS) -s
 all: $(TARGET)
 
 mjgps: mjgps.h mjgps.c
-	$(CC) $(CFLAGS) -s -o $@ mjgps.c -lcrypt
+	$(CC) $(CFLAGS) -o $@ mjgps.c $(CRYPTLIB)
 	strip $@
 
 mjrec: mjgps.h mjrec.c
-	$(CC) $(CFLAGS) -static -s -N -o $@ mjrec.c
+	$(CC) $(CFLAGS) $(RECSTATIC) -o $@ mjrec.c
 	strip $@
 
 cygwin: $(TARGETWIN)

--- a/qkmjserver/mjgps.c
+++ b/qkmjserver/mjgps.c
@@ -13,7 +13,8 @@
 #include <string.h>
 #include <netdb.h>
 #include <sys/errno.h>
-#include <termio.h>
+#include <termios.h>
+#include <stdlib.h>
 #include <fcntl.h>
 #include <sys/param.h>
 #include <sys/file.h>
@@ -25,6 +26,47 @@
 /*
  * Global variables 
  */
+/*
+ * Data-file paths, populated by init_data_dir() at startup.
+ */
+char RECORD_FILE[512];
+char INDEX_FILE[512];
+char NEWS_FILE[512];
+char BADUSER_FILE[512];
+char LOG_FILE[512];
+char GAME_FILE[512];
+
+void show_online_users(int);    /* forward declaration */
+
+/*
+ * Resolve the data directory ($QKMJ_DATA_DIR, else $HOME/.qkmj), create it if
+ * needed, and build the per-file paths. No external setup or sudo required.
+ */
+void init_data_dir(void) {
+	char base[400];
+	const char *dir = getenv("QKMJ_DATA_DIR");
+
+	if (dir && dir[0]) {
+		strncpy(base, dir, sizeof(base) - 1);
+		base[sizeof(base) - 1] = 0;
+	} else {
+		const char *home = getenv("HOME");
+		if (!home || !home[0])
+			home = ".";
+		snprintf(base, sizeof(base), "%s/.qkmj", home);
+	}
+	if (mkdir(base, 0755) != 0 && errno != EEXIST)
+		printf("Warning: cannot create data dir %s\n", base);
+
+	snprintf(RECORD_FILE, sizeof(RECORD_FILE), "%s/qkmj.rec", base);
+	snprintf(INDEX_FILE, sizeof(INDEX_FILE), "%s/qkmj.inx", base);
+	snprintf(NEWS_FILE, sizeof(NEWS_FILE), "%s/news.txt", base);
+	snprintf(BADUSER_FILE, sizeof(BADUSER_FILE), "%s/baduser.txt", base);
+	snprintf(LOG_FILE, sizeof(LOG_FILE), "%s/qkmj.log", base);
+	snprintf(GAME_FILE, sizeof(GAME_FILE), "%s/qkmj_game.log", base);
+	printf("Data dir: %s\n", base);
+}
+
 int timeup = 0;
 extern int errno;
 fd_set rfds, afds;
@@ -1284,6 +1326,8 @@ int checkpasswd(char *passwd, char *test) {
 
 void main(int argc, char **argv) {
 	int i;
+
+	init_data_dir();
 
 	/*
 	 * Set fd to be the maximum number 

--- a/qkmjserver/mjgps.h
+++ b/qkmjserver/mjgps.h
@@ -20,7 +20,7 @@ extern char BADUSER_FILE[];
 extern char LOG_FILE[];
 extern char GAME_FILE[];
 
-#define DEFAULT_RECORD_FILE RECORD_FILE
+#define DEFAULT_RECORD_FILE "qkmj.rec"  /* mjrec default; pass full path as argv[1], e.g. ~/.qkmj/qkmj.rec */
 #define DEFAULT_MONEY 40000
 
 

--- a/qkmjserver/mjgps.h
+++ b/qkmjserver/mjgps.h
@@ -8,14 +8,19 @@
 #define ASK_MODE 1
 #define CMD_MODE 2
 
-#define RECORD_FILE "/var/qkrecord/qkmj.rec"
-#define INDEX_FILE "/var/qkrecord/qkmj.inx"
-#define NEWS_FILE "/var/qkrecord/news.txt"
-#define BADUSER_FILE "/var/qkrecord/baduser.txt"
-#define LOG_FILE "/var/qkrecord/qkmj.log"
-#define GAME_FILE "/var/qkrecord/qkmj_game.log"
+/*
+ * Data-file paths are built at runtime from the data directory:
+ * $QKMJ_DATA_DIR if set, otherwise $HOME/.qkmj (auto-created on startup).
+ * See init_data_dir() in mjgps.c.
+ */
+extern char RECORD_FILE[];
+extern char INDEX_FILE[];
+extern char NEWS_FILE[];
+extern char BADUSER_FILE[];
+extern char LOG_FILE[];
+extern char GAME_FILE[];
 
-#define DEFAULT_RECORD_FILE "/var/qkrecord/qkmj.rec"
+#define DEFAULT_RECORD_FILE RECORD_FILE
 #define DEFAULT_MONEY 40000
 
 


### PR DESCRIPTION
Opened in response to #10 — no pressure to take this as-is; happy to adjust
or split it up, and feel free to close if it's not a direction you want.

This makes QKMJ build and run natively on macOS (Apple Silicon), and fixes two
portability bugs found along the way.

## Bug fixes
1. `init_socket()` (qkmjclient/socket.c) had no `return 0` on the success path,
   so it returned an undefined value. On arm64 that's typically negative, so
   the client wrongly reported "cannot connect" and exited even though the
   server had already accepted the connection. Undefined behavior on every
   platform; arm64 just exposes it.
2. Server data files were hardcoded under `/var/qkrecord` (needs sudo). They
   now live in `$QKMJ_DATA_DIR` (env override) or `$HOME/.qkmj`, auto-created
   at startup.

## Build / portability
- `<termio.h>` (Linux-only, unused) → `<termios.h>`; add `<stdlib.h>`; forward
  declarations for `show_online_users` / `show_card`.
- Cross-platform Makefiles (uname-gated): drop `-lcrypt` / `-static` on macOS;
  add `-std=gnu89` + `-Wno-*` so modern clang/gcc accept the K&R sources.
  Linux/Cygwin build paths are preserved. `make` produces mjgps, mjrec, qkmj.
- README: native macOS build/run, the data dir, and the Big5 terminal note.

## Notes
- Sources are Big5-encoded; all edits were applied byte-safely so the existing
  Big5 string literals are untouched.
- Two commits, split as "bug/source fixes" and "build + docs", so they can be
  reviewed or cherry-picked independently.

Closes #10
